### PR TITLE
fix: SECURITY-1966 vulnerability fix and modernize plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.8</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,12 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+    forkCount: '1C', // Run parallel tests on ci.jenkins.io for lower costs, faster feedback
+    useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+    configurations: [
+        [platform: 'linux', jdk: 21],
+        [platform: 'windows', jdk: 17],
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Copy Data to Workspace Plugin
+
+This Jenkins plugin copies data from a specified folder within `$JENKINS_HOME/userContent` directory to the project workspace before each build.
+
+## Features
+
+- Copy files and directories recursively from `$JENKINS_HOME/userContent` to workspace
+- Make files executable on Unix/Linux systems (chmod 0755)
+- Optional automatic cleanup after build completion
+- Path validation for security
+- Cross-platform support (Windows/Linux)
+
+## Usage
+
+1. Place your files in a subdirectory of `$JENKINS_HOME/userContent`
+2. Configure the plugin in your job:
+   - Enter the relative path to your data folder
+   - Optionally enable "Make files executable"
+   - Optionally enable "Delete files after build"
+
+### Example
+
+If your Jenkins home is `C:\Jenkins` and you want to copy files from `C:\Jenkins\userContent\data\project1`, enter `data\project1` in the plugin path configuration.
+
+### Notes
+
+- Files are copied before the build starts
+- Executable permissions (0755) are set only on Unix/Linux systems
+- When deletion is enabled, files are removed after build completion
+- Ensure build artifacts are not in the copied files list if you need to preserve them
+
+## Requirements
+
+- Java 11 or newer

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This Jenkins plugin copies data from a specified folder within `$JENKINS_HOME/us
 ## Features
 
 - Copy files and directories recursively from `$JENKINS_HOME/userContent` to workspace
-- Make files executable on Unix/Linux systems (chmod 0755)
-- Optional automatic cleanup after build completion
+- Optional: Make files executable on Unix/Linux systems (chmod 0755)
+- Optional: Automatic cleanup after build completion
 - Path validation for security
 - Cross-platform support (Windows/Linux)
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,19 +1,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<artifactId>copy-data-to-workspace-plugin</artifactId>
-	<version>${revision}${changelist}</version>
-	<name>Copy data to workspace plugin</name>
-	<description>Copies data to workspace directory for each project build</description>
-	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
-	<packaging>hpi</packaging>
-
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
 		<version>4.75</version>
 		<relativePath/>
 	</parent>
+
+	<groupId>org.jvnet.hudson.plugins</groupId>
+	<artifactId>copy-data-to-workspace-plugin</artifactId>
+	<version>${revision}${changelist}</version>
+	<name>Copy data to workspace plugin</name>
+	<description>Copies data to workspace directory for each project build</description>
+	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
+	<packaging>hpi</packaging>
 
 	<properties>
 		<revision>2.0</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,16 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.jenkins-ci.plugins</groupId>
-		<artifactId>plugin</artifactId>
-		<version>4.75</version>
-		<relativePath/>
-	</parent>
-	<properties>
-		<jenkins.version>2.462.3</jenkins.version>
-	</properties>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.75</version>
+        <relativePath/>
+    </parent>
+    <properties>
+        <jenkins.version>2.462.3</jenkins.version>
+        <spotbugs.effort>Max</spotbugs.effort>
+        <spotbugs.threshold>Low</spotbugs.threshold>
+    </properties>
 	<artifactId>copy-data-to-workspace-plugin</artifactId>
 	<version>2.0-SNAPSHOT</version>
 	<name>Copy data to workspace plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>copy-data-to-workspace-plugin</artifactId>
-	<version>2.0-SNAPSHOT</version>
+	<version>${revision}${changelist}</version>
 	<name>Copy data to workspace plugin</name>
 	<description>Copies data to workspace directory for each project build</description>
 	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
@@ -16,6 +16,9 @@
 	</parent>
 
 	<properties>
+		<revision>2.0</revision>
+		<changelist>-SNAPSHOT</changelist>
+		<gitHubRepo>jenkinsci/copy-data-to-workspace-plugin</gitHubRepo>
 		<jenkins.baseline>2.462</jenkins.baseline>
 		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
 		<spotbugs.effort>Max</spotbugs.effort>
@@ -43,9 +46,9 @@
 	</dependencies>
 
 	<scm>
-		<connection>scm:git:https://github.com/jenkinsci/copy-data-to-workspace-plugin.git</connection>
-		<developerConnection>scm:git:git@github.com:jenkinsci/copy-data-to-workspace-plugin.git</developerConnection>
-		<url>https://github.com/jenkinsci/copy-data-to-workspace-plugin</url>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+		<url>https://github.com/${gitHubRepo}</url>
 		<tag>${scmTag}</tag>
 	</scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,65 +1,71 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>1.366</version><!-- which version of Hudson is this plugin built against? -->
-    <relativePath>../pom.xml</relativePath>
-  </parent>
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>4.75</version>
+		<relativePath/>
+	</parent>
+	<properties>
+		<jenkins.version>2.387.3</jenkins.version>
+		<java.level>11</java.level>
+	</properties>
+	<artifactId>copy-data-to-workspace-plugin</artifactId>
+	<version>2.0-SNAPSHOT</version>
+	<name>Copy data to workspace plugin</name>
+	<description>Copies data to workspace directory for each project build</description>
+	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
+	<packaging>hpi</packaging>
 
-  <artifactId>copy-data-to-workspace-plugin</artifactId>
-  <version>1.1-SNAPSHOT</version>
-  <name>Copy data to workspace plugin</name>
-  <description>Copies data to workspace directory for each project build</description>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Copy+Data+To+Workspace+Plugin</url>
-  <packaging>hpi</packaging>
-  
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
-  
-  <developers>
-    <developer>
-      <id>nzhelyakov</id>
-      <name>Nikita Zhelyakov</name>
-      <email>nzhelyakov@gmail.com</email>
-    </developer>
-  </developers>
-  
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <configuration>
-          <goals>deploy</goals>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-  
-  <scm>
-    <connection>scm:svn:https://svn.jenkins-ci.org/trunk/hudson/plugins/copy-data-to-workspace-plugin</connection>
-    <developerConnection>scm:svn:https://svn.jenkins-ci.org/trunk/hudson/plugins/copy-data-to-workspace-plugin</developerConnection>
-    <url>https://hudson.dev.java.net/source/browse/hudson/trunk/hudson/plugins/copy-data-to-workspace-plugin</url>
-  </scm>
+	<developers>
+		<developer>
+			<id>nzhelyakov</id>
+			<name>Nikita Zhelyakov</name>
+			<email>nzhelyakov@gmail.com</email>
+		</developer>
+		<developer>
+			<id>jimmyleocn</id>
+			<name>Jimmy Leo</name>
+			<email>taroer@gmail.com</email>
+		</developer>
+	</developers>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.jenkins-ci.tools</groupId>
+				<artifactId>maven-hpi-plugin</artifactId>
+				<version>3.48</version>
+			</plugin>
+			<plugin>
+				<artifactId>maven-release-plugin</artifactId>
+				<configuration>
+					<goals>deploy</goals>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+	<scm>
+		<connection>scm:git:https://github.com/jenkinsci/copy-data-to-workspace-plugin.git</connection>
+		<developerConnection>scm:git:git@github.com:jenkinsci/copy-data-to-workspace-plugin.git</developerConnection>
+		<url>https://github.com/jenkinsci/copy-data-to-workspace-plugin</url>
+		<tag>${scmTag}</tag>
+	</scm>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-</project>  
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>https://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>https://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
+</project>
   
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
 	</parent>
 	<properties>
 		<jenkins.version>2.387.3</jenkins.version>
-		<java.level>11</java.level>
 	</properties>
 	<artifactId>copy-data-to-workspace-plugin</artifactId>
 	<version>2.0-SNAPSHOT</version>
@@ -16,35 +15,6 @@
 	<description>Copies data to workspace directory for each project build</description>
 	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
 	<packaging>hpi</packaging>
-
-	<developers>
-		<developer>
-			<id>nzhelyakov</id>
-			<name>Nikita Zhelyakov</name>
-			<email>nzhelyakov@gmail.com</email>
-		</developer>
-		<developer>
-			<id>jimmyleocn</id>
-			<name>Jimmy Leo</name>
-			<email>taroer@gmail.com</email>
-		</developer>
-	</developers>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.jenkins-ci.tools</groupId>
-				<artifactId>maven-hpi-plugin</artifactId>
-				<version>3.48</version>
-			</plugin>
-			<plugin>
-				<artifactId>maven-release-plugin</artifactId>
-				<configuration>
-					<goals>deploy</goals>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 
 	<scm>
 		<connection>scm:git:https://github.com/jenkinsci/copy-data-to-workspace-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 		<relativePath/>
 	</parent>
 	<properties>
-		<jenkins.version>2.387.3</jenkins.version>
+		<jenkins.version>2.462.3</jenkins.version>
 	</properties>
 	<artifactId>copy-data-to-workspace-plugin</artifactId>
 	<version>2.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,22 +1,46 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.75</version>
-        <relativePath/>
-    </parent>
-    <properties>
-        <jenkins.version>2.462.3</jenkins.version>
-        <spotbugs.effort>Max</spotbugs.effort>
-        <spotbugs.threshold>Low</spotbugs.threshold>
-    </properties>
+	<modelVersion>4.0.0</modelVersion>
+
 	<artifactId>copy-data-to-workspace-plugin</artifactId>
 	<version>2.0-SNAPSHOT</version>
 	<name>Copy data to workspace plugin</name>
 	<description>Copies data to workspace directory for each project build</description>
 	<url>https://plugins.jenkins.io/copy-data-to-workspace-plugin/</url>
 	<packaging>hpi</packaging>
+
+	<parent>
+		<groupId>org.jenkins-ci.plugins</groupId>
+		<artifactId>plugin</artifactId>
+		<version>4.75</version>
+		<relativePath/>
+	</parent>
+
+	<properties>
+		<jenkins.baseline>2.462</jenkins.baseline>
+		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
+		<spotbugs.effort>Max</spotbugs.effort>
+		<spotbugs.threshold>Low</spotbugs.threshold>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-${jenkins.baseline}.x</artifactId>
+				<version>4228.v0a_71308d905b_</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 	<scm>
 		<connection>scm:git:https://github.com/jenkinsci/copy-data-to-workspace-plugin.git</connection>
@@ -38,6 +62,7 @@
 			<url>https://repo.jenkins-ci.org/public/</url>
 		</pluginRepository>
 	</pluginRepositories>
+
 </project>
-  
+
 

--- a/src/main/java/hpi/CopyDataToWorkspacePlugin.java
+++ b/src/main/java/hpi/CopyDataToWorkspacePlugin.java
@@ -55,7 +55,7 @@ public class CopyDataToWorkspacePlugin extends BuildWrapper {
 	private String folderPath;
 	private boolean makeFilesExecutable;
 	private boolean deleteFilesAfterBuild;
-	private String[] copiedFiles;
+	private String[] copiedFiles = new String[0];
 	
 	private static final Logger log = Logger.getLogger(CopyDataToWorkspacePlugin.class.getName()); 
 	

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/config.jelly
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 	<f:entry title="${%Path to folder}" field="folderPath">

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-deleteFilesAfterBuild.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-deleteFilesAfterBuild.html
@@ -1,3 +1,11 @@
 <div>
-	Delete all copied files from workspace after build.
+    When enabled, all files copied to the workspace will be automatically deleted after the build completes.
+    <p>
+        <b>Note:</b>
+        <ul>
+            <li>Deletion occurs after the build is fully completed</li>
+            <li>Any files created during the build with the same names might also be deleted</li>
+            <li>Ensure your build artifacts are not in the copied files list if you need to preserve them</li>
+        </ul>
+    </p>
 </div>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-deleteFilesAfterBuild.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-deleteFilesAfterBuild.html
@@ -1,5 +1,5 @@
 <div>
-    When enabled, all files copied to the workspace will be automatically deleted after the build completes.
+    This optional feature automatically deletes all files copied to the workspace after the build completes.
     <p>
         <b>Note:</b>
         <ul>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-folderPath.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-folderPath.html
@@ -1,7 +1,20 @@
 <div>
   Enter the path to a data storage directory. All data in this directory will
-  be copied to workspace. Path should be relative to Hudson root path(HUDSON_HOME).
+  be copied to workspace. Path should be relative to JENKINS_HOME/userContent directory.
   <br>
-  For example, Hudson root path = "C:\tmp". Path to folder = "storage\task".
-  Plugin will copy data from directory "C:\tmp\storage\task".
+  For example:
+  <ul>
+    <li>JENKINS_HOME = "C:\Jenkins"</li>
+    <li>Valid path = "data\project1"</li>
+    <li>Plugin will copy data from "C:\Jenkins\userContent\data\project1"</li>
+  </ul>
+  <p>
+    <b>Note:</b>
+    <ul>
+      <li>Only relative paths are allowed</li>
+      <li>Path must be within JENKINS_HOME/userContent directory</li>
+      <li>Path traversal characters (.., ~) are not allowed</li>
+      <li>Special characters (&lt;, &gt;, :, ", |, ?, *) are not allowed on Windows</li>
+    </ul>
+  </p>
 </div>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-folderPath.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-folderPath.html
@@ -1,6 +1,6 @@
 <div>
   Enter the path to a data storage directory. All data in this directory will
-  be copied to workspace. Path should be relative to JENKINS_HOME/userContent directory.
+  be copied to workspace. Path should be relative to $JENKINS_HOME/userContent directory.
   <br>
   For example:
   <ul>
@@ -12,7 +12,7 @@
     <b>Note:</b>
     <ul>
       <li>Only relative paths are allowed</li>
-      <li>Path must be within JENKINS_HOME/userContent directory</li>
+      <li>Path must be within $JENKINS_HOME/userContent directory</li>
       <li>Path traversal characters (.., ~) are not allowed</li>
       <li>Special characters (&lt;, &gt;, :, ", |, ?, *) are not allowed on Windows</li>
     </ul>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-makeFilesExecutable.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-makeFilesExecutable.html
@@ -1,5 +1,5 @@
 <div>
-    Sets executable permissions (chmod 0755) for all copied files after copying them to the workspace.
+    This optional feature sets executable permissions (chmod 0755) for all copied files after copying them to the workspace.
     <p>
         <b>Note:</b>
         <ul>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-makeFilesExecutable.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help-makeFilesExecutable.html
@@ -1,4 +1,11 @@
 <div>
-	After copying data to workspace plugin apply to each file chmod(0755).
-	So all files become executable. On Windows, no-op.
+    Sets executable permissions (chmod 0755) for all copied files after copying them to the workspace.
+    <p>
+        <b>Note:</b>
+        <ul>
+            <li>This option has no effect on Windows systems</li>
+            <li>On Unix/Linux systems, all files will be made executable</li>
+            <li>Permission 0755 means: owner can read/write/execute, group and others can read/execute</li>
+        </ul>
+    </p>
 </div>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
@@ -1,5 +1,5 @@
 <div>
     Before each build, this plugin copies data from a specified folder within $JENKINS_HOME/userContent directory to the project workspace.
-    Files can be made executable for Unix/Linux systems.
+    Optionally, files can be made executable for Unix/Linux systems.
     Optionally, copied files can be automatically deleted after build completion.
 </div>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
@@ -1,4 +1,5 @@
 <div>
-	Before each build copies data from specified folder to workspace. 
-	After build data will be deleted.
+    Before each build, this plugin copies data from a specified folder within JENKINS_HOME/userContent directory to the project workspace.
+    Files can be made executable for Unix/Linux systems.
+    Optionally, copied files can be automatically deleted after build completion.
 </div>

--- a/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
+++ b/src/main/resources/hpi/CopyDataToWorkspacePlugin/help.html
@@ -1,5 +1,5 @@
 <div>
-    Before each build, this plugin copies data from a specified folder within JENKINS_HOME/userContent directory to the project workspace.
+    Before each build, this plugin copies data from a specified folder within $JENKINS_HOME/userContent directory to the project workspace.
     Files can be made executable for Unix/Linux systems.
     Optionally, copied files can be automatically deleted after build completion.
 </div>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
-  This plugin copies data to workspace directory before each build. After build data will be deleted.
+  Copies data from JENKINS_HOME/userContent directory to workspace for each project build. Files can be made executable and optionally deleted after build completion.
 </div>

--- a/src/test/java/hpi/CopyDataToWorkspacePluginTest.java
+++ b/src/test/java/hpi/CopyDataToWorkspacePluginTest.java
@@ -1,0 +1,112 @@
+package hpi;
+
+// Hudson/Jenkins imports
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.util.FormValidation;
+import static hudson.Functions.isWindows;
+
+// JUnit imports
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.BuildWatcher;
+
+// Java standard imports
+import java.io.IOException;
+
+public class CopyDataToWorkspacePluginTest {
+    private static final String TEST_FILE_NAME = "test.txt";
+    private static final String TEST_CONTENT = "test content";
+    private static final String TEST_DIR = "testDir";
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Rule
+    public BuildWatcher watcher = new BuildWatcher();
+
+    private FilePath userContent;
+    private FilePath testDir;
+
+    @Before
+    public void setUp() throws IOException, InterruptedException {
+        userContent = j.jenkins.getRootPath().child("userContent");
+        testDir = userContent.child(TEST_DIR);
+        testDir.mkdirs();
+    }
+
+    private void createTestFile() throws IOException, InterruptedException {
+        testDir.child(TEST_FILE_NAME).write(TEST_CONTENT, "UTF-8");
+    }
+
+    private FreeStyleBuild createAndBuildProject(CopyDataToWorkspacePlugin plugin) throws Exception {
+        FreeStyleProject project = j.createFreeStyleProject();
+        project.getBuildWrappersList().add(plugin);
+        return j.buildAndAssertSuccess(project);
+    }
+
+    @Test
+    public void testBasicCopy() throws Exception {
+        createTestFile();
+
+        CopyDataToWorkspacePlugin plugin = new CopyDataToWorkspacePlugin(
+            TEST_DIR,
+            false,
+            false
+        );
+
+        FreeStyleBuild build = createAndBuildProject(plugin);
+        
+        FilePath workspace = build.getWorkspace();
+        assertTrue("File should be copied to workspace", 
+            workspace.child(TEST_FILE_NAME).exists());
+        assertEquals("File content should match", 
+            TEST_CONTENT, workspace.child(TEST_FILE_NAME).readToString());
+    }
+
+    @Test
+    public void testDeleteAfterBuild() throws Exception {
+        createTestFile();
+
+        CopyDataToWorkspacePlugin plugin = new CopyDataToWorkspacePlugin(
+            TEST_DIR,
+            false,
+            true
+        );
+
+        FreeStyleBuild build = createAndBuildProject(plugin);
+        
+        FilePath workspace = build.getWorkspace();
+        assertFalse("File should be deleted after build", 
+            workspace.child(TEST_FILE_NAME).exists());
+    }
+
+    @Test
+    public void testInvalidPaths() {
+        // Test path with parent directory traversal
+        FormValidation validation = CopyDataToWorkspacePlugin.DescriptorImpl.validateFolderPath("../test");
+        assertEquals("Parent directory traversal should be rejected", 
+            FormValidation.Kind.ERROR, validation.kind);
+
+        // Test path with tilde
+        validation = CopyDataToWorkspacePlugin.DescriptorImpl.validateFolderPath("~/test");
+        assertEquals("Paths with tilde should be rejected", 
+            FormValidation.Kind.ERROR, validation.kind);
+
+        if (isWindows()) {
+            // Test Windows absolute path
+            validation = CopyDataToWorkspacePlugin.DescriptorImpl.validateFolderPath("C:\\test");
+            assertEquals("Windows absolute paths should be rejected", 
+                FormValidation.Kind.ERROR, validation.kind);
+    
+            // Test UNC path
+            validation = CopyDataToWorkspacePlugin.DescriptorImpl.validateFolderPath("\\\\server\\share");
+            assertEquals("UNC paths should be rejected", 
+                FormValidation.Kind.ERROR, validation.kind);
+        }
+    }
+}


### PR DESCRIPTION
# Jenkins Copy Data to Workspace Plugin Updates

## 1. Security Enhancement (SECURITY-1966)
[Reference URL](https://www.jenkins.io/security/advisory/2020-09-16/#SECURITY-1966)
Implemented comprehensive path security validation mechanisms, including:
- Restriction of file access scope to $JENKINS_HOME/userContent
- Prevention of directory traversal attacks (blocking special path characters like `..`)
- Path character validation specific to Windows/Unix systems
- Prevention of absolute path usage

## 2. Technology Stack Modernization
Core dependencies updated to current stable versions:
- Set minimum Jenkins version requirement to 2.462.3 LTS for latest security features
- Updated Jenkins parent plugin to 4.75 for modern plugin development support
- Migrated version control system from SVN to Git for better collaboration
