### PR TITLE
fix: Add symlink safety check to prevent directory traversal and unit test

### DIFF
--- a/src/main/java/hpi/CopyDataToWorkspacePlugin.java
+++ b/src/main/java/hpi/CopyDataToWorkspacePlugin.java
@@ -252,6 +252,9 @@ public class CopyDataToWorkspacePlugin extends BuildWrapper {
         
         @Override
         public void checkRoles(org.jenkinsci.remoting.RoleChecker checker) throws SecurityException {
+            if (checker == null) {
+                throw new SecurityException("RoleChecker cannot be null");
+            }
             checker.check(this, org.jenkinsci.remoting.Role.UNKNOWN);
         }
     }

--- a/src/main/java/hpi/CopyDataToWorkspacePlugin.java
+++ b/src/main/java/hpi/CopyDataToWorkspacePlugin.java
@@ -240,6 +240,15 @@ public class CopyDataToWorkspacePlugin extends BuildWrapper {
         boolean isSafe = realPath.startsWith(rootRealPath + java.io.File.separator) 
                || realPath.equals(rootRealPath);
 
+        // Recursively check subdirectories for symlinks pointing outside
+        if (isSafe && path.isDirectory()) {
+            for (FilePath child : path.list()) {
+                if (!doCheckSymlinkSafe(child, allowedRoot)) {
+                    return false;
+                }
+            }
+        }
+
         return isSafe;
     }
     

--- a/src/main/java/hpi/CopyDataToWorkspacePlugin.java
+++ b/src/main/java/hpi/CopyDataToWorkspacePlugin.java
@@ -43,7 +43,6 @@ import jenkins.model.Jenkins;
 import java.io.IOException;
 import java.util.List;
 import java.util.logging.Logger;
-import java.nio.file.Path;
 
 // JSON/Stapler imports
 import net.sf.json.JSONObject;
@@ -234,31 +233,21 @@ public class CopyDataToWorkspacePlugin extends BuildWrapper {
     }
 	
     private boolean doCheckSymlinkSafe(FilePath path, FilePath allowedRoot) throws IOException, InterruptedException {
-        try {
-            String realPath = path.act(new PathResolver());
-            String rootRealPath = allowedRoot.act(new PathResolver());
-            
-            // Check if the resolved path is within the allowed root directory
-            boolean isSafe = realPath.startsWith(rootRealPath + java.io.File.separator) 
-                   || realPath.equals(rootRealPath);
+        String realPath = path.act(new PathResolver());
+        String rootRealPath = allowedRoot.act(new PathResolver());
+        
+        // Check if the resolved path is within the allowed root directory
+        boolean isSafe = realPath.startsWith(rootRealPath + java.io.File.separator) 
+               || realPath.equals(rootRealPath);
 
-            return isSafe;
-            
-        } catch (IOException e) {
-            log.warning("Failed to resolve real path: " + e.getMessage());
-            return false;
-        }
+        return isSafe;
     }
     
     private static class PathResolver implements hudson.FilePath.FileCallable<String> {
         private static final long serialVersionUID = 1L;
         
         public String invoke(java.io.File f, hudson.remoting.VirtualChannel channel) throws IOException {
-            try {
-                return f.toPath().toRealPath().toString();
-            } catch (Exception e) {
-                throw new IOException("Failed to resolve real path: " + e.getMessage(), e);
-            }
+            return f.toPath().toRealPath().toString();
         }
         
         @Override

--- a/src/test/java/hpi/CopyDataToWorkspacePluginTest.java
+++ b/src/test/java/hpi/CopyDataToWorkspacePluginTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.kohsuke.stapler.StaplerRequest2;
-
 import static hudson.Functions.isWindows;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -564,7 +563,7 @@ class CopyDataToWorkspacePluginTest {
         
         // Test invalid path outside userContent
         CopyDataToWorkspacePlugin invalidPlugin = new CopyDataToWorkspacePlugin(
-                "../outside-user-content", false, false);
+                "../userContentBis", false, false);
         FreeStyleProject invalidProject = j.createFreeStyleProject();
         invalidProject.getBuildWrappersList().add(invalidPlugin);
         


### PR DESCRIPTION
Added `doCheckSymlinkSafe` method in CopyDataToWorkspacePlugin to check if symlinks in the path point outside the allowed root directory. This fix prevents potential directory traversal attacks, ensuring the source path always remains within the JENKINS_HOME/userContent directory.